### PR TITLE
enable clangd and LSP settings for Zed

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -1,0 +1,27 @@
+CompileFlags:
+    CompilationDatabase: ./
+    # compiler builtin paths aren't set in compile_comamnds.json
+    # so they must be manually specified here
+    Add:
+        - "-nostdinc++"
+        - "-isystem"
+        - "external/toolchains_llvm++llvm+llvm_toolchain_llvm/include/c++/v1"
+Index:
+    Background: Build
+    StandardLibrary: yes
+Diagnostics:
+    ClangTidy:
+        FastCheckFilter: Loose
+    UnusedIncludes: Strict
+    MissingIncludes: Strict
+Completion:
+    AllScopes: Yes
+InlayHints:
+    Enabled: Yes
+    ParameterNames: Yes
+    DeducedTypes: Yes
+    Designators: Yes
+    BlockEnd: Yes
+    TypeNameLimit: 0
+Hover:
+    ShowAKA: Yes

--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -1,0 +1,41 @@
+// Folder-specific settings
+//
+// For a full list of overridable settings, and general information on folder-specific settings,
+// see the documentation: https://zed.dev/docs/configuring-zed#settings-files
+{
+  "format_on_save": "off",
+  "file_scan_exclusions": [".cache/"],
+  "languages": {
+    "Starlark": {
+      "enable_language_server": true,
+      "language_servers": ["starpls"] // very buggy =/
+    }
+  },
+  // This uses the hermetic clangd from the llvm toolchain, but arguments
+  // may vary due to personal preference.
+  //
+  // https://github.com/zed-industries/zed/discussions/6629#discussioncomment-10493418
+  // https://github.com/zed-industries/zed/issues/4295#issuecomment-2287229162
+  "lsp": {
+    "clangd": {
+      "binary": {
+        "path": "./external/toolchains_llvm++llvm+llvm_toolchain_llvm/bin/clangd",
+        "arguments": [
+          "--function-arg-placeholders=0",
+          "--completion-parse=always",
+          "--all-scopes-completion",
+          "--clang-tidy",
+          "--debug-origin",
+          "--header-insertion=iwyu",
+          "--header-insertion-decorators",
+          "--include-ineligible-results",
+          "--import-insertions",
+          "--limit-references=0",
+          "--limit-results=0",
+          "--rename-file-limit=0",
+          "--log=verbose"
+        ]
+      }
+    }
+  }
+}

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -16,6 +16,16 @@ bazel_dep(
     dev_dependency = True,
 )
 bazel_dep(
+    name = "hedron_compile_commands",
+    version = "",
+    dev_dependency = True,
+)
+bazel_dep(
+    name = "platforms",
+    version = "1.0.0",
+    dev_dependency = True,
+)
+bazel_dep(
     name = "buildifier_prebuilt",
     version = "8.2.0.2",
     dev_dependency = True,
@@ -111,6 +121,19 @@ archive_override(
     ),
     urls = ["https://github.com/oliverlee/rules_clang_tidy/archive/{commit}.tar.gz".format(
         commit = RULES_CLANG_TIDY_COMMIT,
+    )],
+)
+
+HEDRON_COMPILE_COMMANDS_COMMIT = "4f28899228fb3ad0126897876f147ca15026151e"
+
+archive_override(
+    module_name = "hedron_compile_commands",
+    integrity = "sha256-ZYEiz7HyW+duohKwD16wR9jirci8+SO5GEYfKx43zfI=",
+    strip_prefix = "bazel-compile-commands-extractor-{commit}".format(
+        commit = HEDRON_COMPILE_COMMANDS_COMMIT,
+    ),
+    urls = ["https://github.com/hedronvision/bazel-compile-commands-extractor/archive/{commit}.tar.gz".format(
+        commit = HEDRON_COMPILE_COMMANDS_COMMIT,
     )],
 )
 

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -46,12 +46,13 @@
     "https://bcr.bazel.build/modules/libpfm/4.11.0/MODULE.bazel": "45061ff025b301940f1e30d2c16bea596c25b176c8b6b3087e92615adbd52902",
     "https://bcr.bazel.build/modules/platforms/0.0.10/MODULE.bazel": "8cb8efaf200bdeb2150d93e162c40f388529a25852b332cec879373771e48ed5",
     "https://bcr.bazel.build/modules/platforms/0.0.11/MODULE.bazel": "0daefc49732e227caa8bfa834d65dc52e8cc18a2faf80df25e8caea151a9413f",
-    "https://bcr.bazel.build/modules/platforms/0.0.11/source.json": "f7e188b79ebedebfe75e9e1d098b8845226c7992b307e28e1496f23112e8fc29",
     "https://bcr.bazel.build/modules/platforms/0.0.4/MODULE.bazel": "9b328e31ee156f53f3c416a64f8491f7eb731742655a47c9eec4703a71644aee",
     "https://bcr.bazel.build/modules/platforms/0.0.5/MODULE.bazel": "5733b54ea419d5eaf7997054bb55f6a1d0b5ff8aedf0176fef9eea44f3acda37",
     "https://bcr.bazel.build/modules/platforms/0.0.6/MODULE.bazel": "ad6eeef431dc52aefd2d77ed20a4b353f8ebf0f4ecdd26a807d2da5aa8cd0615",
     "https://bcr.bazel.build/modules/platforms/0.0.7/MODULE.bazel": "72fd4a0ede9ee5c021f6a8dd92b503e089f46c227ba2813ff183b71616034814",
     "https://bcr.bazel.build/modules/platforms/0.0.8/MODULE.bazel": "9f142c03e348f6d263719f5074b21ef3adf0b139ee4c5133e2aa35664da9eb2d",
+    "https://bcr.bazel.build/modules/platforms/1.0.0/MODULE.bazel": "f05feb42b48f1b3c225e4ccf351f367be0371411a803198ec34a389fb22aa580",
+    "https://bcr.bazel.build/modules/platforms/1.0.0/source.json": "f4ff1fd412e0246fd38c82328eb209130ead81d62dcd5a9e40910f867f733d96",
     "https://bcr.bazel.build/modules/protobuf/21.7/MODULE.bazel": "a5a29bb89544f9b97edce05642fac225a808b5b7be74038ea3640fae2f8e66a7",
     "https://bcr.bazel.build/modules/protobuf/23.1/MODULE.bazel": "88b393b3eb4101d18129e5db51847cd40a5517a53e81216144a8c32dfeeca52a",
     "https://bcr.bazel.build/modules/protobuf/24.4/MODULE.bazel": "7bc7ce5f2abf36b3b7b7c8218d3acdebb9426aeb35c2257c96445756f970eb12",
@@ -148,6 +149,56 @@
   },
   "selectedYankedVersions": {},
   "moduleExtensions": {
+    "@@hedron_compile_commands+//:workspace_setup.bzl%hedron_compile_commands_extension": {
+      "general": {
+        "bzlTransitiveDigest": "7Ey+orEPG9KH85wB77is9jsTlAqjXehBmrGP1vKxaCk=",
+        "usagesDigest": "CbJ2MjubH36j9xaONhhASfhodhpi5fzvuyg/IW2f7Ds=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {},
+        "recordedRepoMappingEntries": [
+          [
+            "hedron_compile_commands+",
+            "bazel_tools",
+            "bazel_tools"
+          ]
+        ]
+      }
+    },
+    "@@hedron_compile_commands+//:workspace_setup_transitive.bzl%hedron_compile_commands_extension": {
+      "general": {
+        "bzlTransitiveDigest": "IfDf0vEa2jjQ11RNpUM0u4xftPXIs+pyM8IMVkRqVMk=",
+        "usagesDigest": "yxZQbFglJyjpn7JZ9mhIc3EhLzZivlbs6wiHWOKJ/UA=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {},
+        "recordedRepoMappingEntries": []
+      }
+    },
+    "@@hedron_compile_commands+//:workspace_setup_transitive_transitive.bzl%hedron_compile_commands_extension": {
+      "general": {
+        "bzlTransitiveDigest": "1p58k3o2Jgjt/pBE7cb8WmmkplrSguIKma/h32x7X10=",
+        "usagesDigest": "GkOuy/k8wz0dbKMeEJFKEJB3CWkMZt3DYcPgj4lALkI=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {},
+        "recordedRepoMappingEntries": []
+      }
+    },
+    "@@hedron_compile_commands+//:workspace_setup_transitive_transitive_transitive.bzl%hedron_compile_commands_extension": {
+      "general": {
+        "bzlTransitiveDigest": "arNWX4EleUjJxqkM5nCRTj+ce05Zz1gSdGH1DCKOoLs=",
+        "usagesDigest": "WZExKK/BI4lqpUZfPpv4YARDE1Y7igQB+wYGKvNoCKs=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {},
+        "recordedRepoMappingEntries": []
+      }
+    },
     "@@pybind11_bazel+//:python_configure.bzl%extension": {
       "general": {
         "bzlTransitiveDigest": "d4N/SZrl3ONcmzE98rcV0Fsro0iUbjNQFTIiLiGuH+k=",

--- a/sel/BUILD.bazel
+++ b/sel/BUILD.bazel
@@ -1,0 +1,7 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+cc_library(
+    name = "sel",
+    hdrs = ["sel.hpp"],
+    visibility = ["//visibility:public"],
+)

--- a/sel/sel.hpp
+++ b/sel/sel.hpp
@@ -1,0 +1,11 @@
+#pragma once
+
+namespace sel {
+
+[[nodiscard]]
+constexpr auto foo() -> int
+{
+  return 42;
+}
+
+}  // namespace sel

--- a/sel/test/BUILD.bazel
+++ b/sel/test/BUILD.bazel
@@ -4,5 +4,8 @@ cc_test(
     name = "dummy_test",
     size = "small",
     srcs = ["dummy_test.cpp"],
-    deps = ["@skytest"],
+    deps = [
+        "//sel",
+        "@skytest",
+    ],
 )

--- a/sel/test/dummy_test.cpp
+++ b/sel/test/dummy_test.cpp
@@ -1,9 +1,11 @@
+#include "sel/sel.hpp"
 #include "skytest/skytest.hpp"
 
 auto main() -> int
 {
   using namespace skytest::literals;
+  using ::skytest::eq;
   using ::skytest::expect;
 
-  "dummy test"_ctest = [] { return expect(true); };
+  "dummy test"_test = [] { return expect(eq(42, sel::foo())); };
 }

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@buildifier_prebuilt//:rules.bzl", "buildifier")
+load("@hedron_compile_commands//:refresh_compile_commands.bzl", "refresh_compile_commands")
 load("@rules_multirun//:defs.bzl", "multirun")
 load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
 
@@ -94,4 +95,19 @@ sh_binary(
 alias(
     name = "lint",
     actual = ":clang-tidy",
+)
+
+alias(
+    name = "clang_toolchain",
+    actual = select({
+        "@platforms//os:macos": "@llvm_toolchain//:cc-toolchain-aarch64-darwin",
+        "@platforms//os:linux": "@llvm_toolchain//:cc-toolchain-x86_64-linux",
+    }),
+)
+
+refresh_compile_commands(
+    name = "compile_commands",
+    targets = {
+        "//sel/...": "--extra_toolchains=//tools:clang_toolchain",
+    },
 )


### PR DESCRIPTION
Add a target to generate a `compile_commands.json` file which can be
used with clangd. This file can be generated with

```
bazel run //tools:compile_commands
```

and will be generated in the root directory.

This file needs to be periodically regenerated, for example, when a new
translation unit is defined.

This commit also defines `.clangd` and `.zed` settings. `.clangd`
defines additional compilation options necessary for use of `clangd`
with the hermetic clang toolchain.

Change-Id: I02ae78c1110a7012611fcaa400adcfc592839c0f