### PR TITLE
add coverage tooling

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -19,4 +19,7 @@ coverage --copt=-ffile-compilation-dir=.
 coverage --combined_report=lcov
 coverage --experimental_generate_llvm_lcov
 
+# https://github.com/bazelbuild/bazel/issues/23719
+coverage:macos --test_env=GCOV_PREFIX_STRIP=10
+
 try-import %workspace%/user.bazelrc

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -41,6 +41,11 @@ bazel_dep(
     dev_dependency = True,
 )
 bazel_dep(
+    name = "bazel_skylib",
+    version = "1.7.1",
+    dev_dependency = True,
+)
+bazel_dep(
     name = "skytest",
     version = "",
     dev_dependency = True,
@@ -148,4 +153,22 @@ archive_override(
     urls = ["https://github.com/oliverlee/skytest/archive/{commit}.tar.gz".format(
         commit = SKYTEST_COMMIT,
     )],
+)
+
+http_archive = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+http_archive(
+    name = "lcov",
+    build_file_content = """\
+load("@bazel_skylib//rules:native_binary.bzl", "native_binary")
+
+native_binary(
+    name = "genhtml",
+    src = "bin/genhtml",
+    visibility = ["//visibility:public"],
+)
+    """,
+    integrity = "sha256-mHAxrVUoyKdG1LUrOAvBv/5BLeHyucK6UiSZVmjjJAs=",
+    strip_prefix = "lcov-1.16",
+    url = "https://github.com/linux-test-project/lcov/releases/download/v1.16/lcov-1.16.tar.gz",
 )

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -111,3 +111,70 @@ refresh_compile_commands(
         "//sel/...": "--extra_toolchains=//tools:clang_toolchain",
     },
 )
+
+genrule(
+    name = "gen-coverage",
+    srcs = ["@lcov//:genhtml"],
+    outs = ["coverage.bash"],
+    cmd = """
+echo "#!/bin/bash" > $@
+echo "set -euo pipefail" >> $@
+echo "" >> $@
+echo "cd \\$$BUILD_WORKSPACE_DIRECTORY" >> $@
+echo "COVERAGE_DIR={cov_dir}" >> $@
+echo "bazelisk coverage \\$${{@:-//...}}" >> $@
+echo "$(execpath @lcov//:genhtml) {options} {report}" >> $@
+echo "" >> $@
+echo "echo wrote coverage report to" >> $@
+echo "echo file://{html}" >> $@
+""".format(
+        cov_dir = "\\$$(bazelisk info output_path)/_coverage",
+        html = "\\$${COVERAGE_DIR}/html/index.html",
+        options = " ".join([
+            "--output-directory \\$${COVERAGE_DIR}/html",
+            "--show-details",
+            "--function-coverage",
+            "--branch-coverage",
+            "--title zipline",
+            "--highlight",
+            "--legend",
+            "--missed",
+            "--demangle-cpp",
+            "--dark-mode",
+        ]),
+        report = "\\$${COVERAGE_DIR}/_coverage_report.dat",
+    ),
+)
+
+sh_binary(
+    name = "coverage",
+    srcs = [":coverage.bash"],
+    args = [
+        "--instrumentation_filter=//sel",
+        "//...",
+    ],
+    data = ["@lcov//:genhtml"],
+)
+
+_coverage_open_script = """
+echo "#!/bin/bash" > $@
+echo "set -euo pipefail" >> $@
+echo "" >> $@
+echo "cd \\$$BUILD_WORKSPACE_DIRECTORY" >> $@
+echo "exec {{cmd}} {html}" >> $@
+""".format(
+    html = "\\$$(bazelisk info output_path)/_coverage/html/index.html",
+)
+
+# due to sh_binary tokenization, we can't use a generic open command and pass
+# the path as an argument
+# https://github.com/bazelbuild/bazel/issues/12313
+genrule(
+    name = "coverage.open",
+    outs = ["coverage.open.bash"],
+    cmd = select({
+        "@platforms//os:macos": _coverage_open_script.format(cmd = "open"),
+        "@platforms//os:linux": _coverage_open_script.format(cmd = "xdg-open"),
+    }),
+    executable = True,
+)


### PR DESCRIPTION
Add Bazel targets for generating code coverage.

```sh
bazel run //tools:coverage
```
generates an HTML coverage report.

```sh
bazel run //tools:coverage.open
```
generates an HTML coverage report and opens it using `open` on macOS and
`xdg-open` on Linux.

Change-Id: I3e22873ebce641544c5d92cf8ae92608f092ba24