### PR TITLE
enable buildbuddy BES and remote cache

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -12,6 +12,19 @@ build --@bazel_clang_format//:config=//:format-config
 build --@rules_clang_tidy//:clang-tidy=@llvm_toolchain//:clang-tidy
 build --@rules_clang_tidy//:config=//:tidy-config
 
+build:remote-cache --bes_results_url=https://digiboys.buildbuddy.io/invocation/
+build:remote-cache --bes_backend=grpcs://digiboys.buildbuddy.io
+build:remote-cache --bes_upload_mode=fully_async
+build:remote-cache --remote_cache=grpcs://digiboys.buildbuddy.io
+build:remote-cache --remote_timeout=10m
+build:remote-cache --remote_build_event_upload=minimal
+build:remote-cache --remote_download_outputs=minimal
+build:remote-cache --remote_cache_compression
+build:remote-cache --slim_profile=false
+build:remote-cache --experimental_profile_include_primary_output
+build:remote-cache --experimental_profile_include_target_label
+build:remote-cache --legacy_important_outputs=false
+
 test --test_verbose_timeout_warnings
 
 # https://github.com/bazelbuild/bazel/issues/14970#issuecomment-1894565761

--- a/.github/actions/ci-env-setup/action.yml
+++ b/.github/actions/ci-env-setup/action.yml
@@ -1,6 +1,11 @@
 name: "CI environment setup"
 description: |
   * set home bazelrc for CI runner
+  * set buildbuddy api key
+
+inputs:
+  buildbuddy-api-key:
+    required: true
 
 runs:
   using: "composite"
@@ -9,3 +14,4 @@ runs:
       shell: bash
       run: |
         cp .github/workflows/ci.bazelrc ~/.bazelrc
+        echo 'build:remote-cache --remote_header=x-buildbuddy-api-key=${{ inputs.buildbuddy-api-key }}' >> ~/.bazelrc

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -22,29 +22,24 @@ jobs:
           - 'ubuntu-latest'
           - 'macos-latest'
     runs-on: ${{ matrix.os }}
-    env:
-      PROFILE: profile-${{ matrix.os }}-${{ matrix.compilation_mode }}-${{ matrix.toolchain }}.gz
     steps:
     - uses: actions/checkout@v4
     - uses: ./.github/actions/ci-env-setup
+      with:
+        buildbuddy-api-key: ${{ secrets.BUILDBUDDY_API_KEY }}
     - run: |
         bazel test \
-          --profile=$PROFILE \
           --compilation_mode=${{ matrix.compilation_mode }} \
           --extra_toolchains=//tools:${{ matrix.toolchain }}_toolchain \
           //...
-
-        bazel analyze-profile $PROFILE
-    - uses: actions/upload-artifact@v4
-      with:
-        name: ${{ env.PROFILE }}
-        path : ${{ env.PROFILE }}
 
   format:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
     - uses: ./.github/actions/ci-env-setup
+      with:
+        buildbuddy-api-key: ${{ secrets.BUILDBUDDY_API_KEY }}
     - run: |
         bazel run //tools:format.check
 
@@ -55,6 +50,8 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: ./.github/actions/ci-env-setup
+      with:
+        buildbuddy-api-key: ${{ secrets.BUILDBUDDY_API_KEY }}
     - id: query
       run: |
         targets=$(\
@@ -77,6 +74,8 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: ./.github/actions/ci-env-setup
+      with:
+        buildbuddy-api-key: ${{ secrets.BUILDBUDDY_API_KEY }}
     - run: |
         bazel run //tools:clang-tidy -- ${{ matrix.target }}
 

--- a/.github/workflows/ci.bazelrc
+++ b/.github/workflows/ci.bazelrc
@@ -1,8 +1,14 @@
+common --build_metadata=ROLE=CI
+
 build --show_timestamps
 build --announce_rc
 build --color=yes
 build --curses=no
 build --terminal_columns=120
 build --verbose_failures
+
+build:remote-cache --remote_upload_local_results=true
+build:remote-cache --remote_instance_name=ci-runner-sel-instance-0
+build --config=remote-cache
 
 test --test_output=errors

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 # bazel convenience symlinks
 /bazel-*
+
+# user-specific config
+user.bazelrc


### PR DESCRIPTION
Add `remote-cache` config to `.bazelrc`. Use of the Bazel Event Service
and the Bazel remote cache can be enabled by specifying the following in
a `user.bazelrc` file:

```
build:remote-cache --remote_header=x-buildbuddy-api-key=<BUILDBUDDY_API_KEY>
build:remote-cache --remote_upload_local_results=true
build:remote-cache --remote_instance_name=<REMOTE_INSTANCE_NAME>

build --config=remote-cache
```

`--profile` flags are removed to allow buildbuddy to display timing
information.

Change-Id: I1c4683b0ae569622baed797f802bfb1819ee904b