### PR TITLE
setup external dep cache for CI runners

### DIFF
--- a/.github/actions/ci-env-setup/action.yml
+++ b/.github/actions/ci-env-setup/action.yml
@@ -2,6 +2,7 @@ name: "CI environment setup"
 description: |
   * set home bazelrc for CI runner
   * set buildbuddy api key
+  * setup vendored external deps
 
 inputs:
   buildbuddy-api-key:
@@ -15,3 +16,15 @@ runs:
       run: |
         cp .github/workflows/ci.bazelrc ~/.bazelrc
         echo 'build:remote-cache --remote_header=x-buildbuddy-api-key=${{ inputs.buildbuddy-api-key }}' >> ~/.bazelrc
+
+    - name: setup bazel vendored external deps
+      shell: bash
+      run: |
+        echo "common --vendor_dir=$HOME/bazel_external_deps" >> ~/.bazelrc
+
+    - name: restore bazel vendored external deps
+      uses: actions/cache/restore@v4
+      with:
+        path: |
+          ~/bazel_external_deps
+        key: bazel-external-cache-${{ runner.os }}

--- a/.github/workflows/external-cache.yml
+++ b/.github/workflows/external-cache.yml
@@ -1,0 +1,56 @@
+name: external-cache
+
+on:
+  schedule:
+    - cron: "0 10 * * *" # UTC
+  workflow_dispatch:
+
+jobs:
+  clear-workflow-external-cache:
+    runs-on:
+      - ubuntu-latest
+    permissions:
+      actions: write
+      contents: read
+    steps:
+    - name: cleanup caches
+      # https://github.com/actions/cache/blob/main/tips-and-workarounds.md#force-deletion-of-caches-overriding-default-cache-eviction-policy
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        gh cache delete --all --succeed-on-no-caches \
+          --repo ${{ github.repository }}
+
+  refresh-workflow-external-cache:
+    needs:
+      - clear-workflow-external-cache
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - 'ubuntu-latest'
+          - 'macos-latest'
+    runs-on: ${{ matrix.os }}
+    permissions:
+      actions: write
+      contents: read
+    steps:
+    - uses: actions/checkout@v4
+    - uses: ./.github/actions/ci-env-setup
+      with:
+        buildbuddy-api-key: ${{ secrets.BUILDBUDDY_API_KEY }}
+    - name: fetch external deps
+      run: |
+        bazel vendor \
+          --vendor_dir=~/bazel_external_deps \
+          //sel/...
+    - name: print vendored external deps
+      run: |
+        ls -al ~/bazel_external_deps/
+        du -sh ~/bazel_external_deps/
+    - name: save to actions/cache
+      uses: actions/cache/save@v4
+      with:
+        path: |
+          ~/bazel_external_deps
+        key: bazel-external-cache-${{ runner.os }}


### PR DESCRIPTION
Add a periodic workflow that vendors Bazel external dependencies. This
reduces the time runners spend downloading and extracting external
dependencies.

Change-Id: I0b31f71cfffc8c8f446773f92d739b550472428a