### PR TITLE
promote integers and floating point to `constant` with `+`

### DIFF
--- a/sel/BUILD.bazel
+++ b/sel/BUILD.bazel
@@ -20,7 +20,10 @@ cc_library(
 cc_library(
     name = "plus",
     hdrs = ["plus.hpp"],
-    deps = [":term"],
+    deps = [
+        ":term",
+        ":term_promotable",
+    ],
 )
 
 cc_library(
@@ -32,6 +35,15 @@ cc_library(
     name = "term",
     hdrs = ["term.hpp"],
     deps = [":strongly_ordered"],
+)
+
+cc_library(
+    name = "term_promotable",
+    hdrs = ["term_promotable.hpp"],
+    deps = [
+        ":constant",
+        ":term",
+    ],
 )
 
 cc_library(

--- a/sel/plus.hpp
+++ b/sel/plus.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "sel/term.hpp"
+#include "sel/term_promotable.hpp"
 
 #include <cstddef>
 #include <format>
@@ -35,26 +36,26 @@ struct plus
     );
   }
 
-  template <term T>
+  template <term_promotable T>
   [[nodiscard]]
   friend constexpr auto operator+(const plus& x, const T& y)
   {
-    return x + plus<T>{y};
+    return x + plus<term_promoted_type_t<T>>{to_term(y)};
   }
 
-  template <term T>
+  template <term_promotable T>
   [[nodiscard]]
   friend constexpr auto operator+(const T& x, const plus& y)
   {
-    return plus<T>{x} + y;
+    return plus<term_promoted_type_t<T>>{to_term(x)} + y;
   }
 };
 
-template <term T1, term T2>
+template <term_promotable T1, term_promotable T2>
 [[nodiscard]]
 constexpr auto operator+(const T1& x, const T2& y)
 {
-  return plus<T1, T2>{x, y};
+  return plus{to_term(x), to_term(y)};
 }
 
 }  // namespace sel

--- a/sel/term_promotable.hpp
+++ b/sel/term_promotable.hpp
@@ -1,0 +1,54 @@
+#pragma once
+
+#include "sel/constant.hpp"
+#include "sel/term.hpp"
+
+#include <concepts>
+#include <type_traits>
+
+namespace sel {
+
+/// returns a `term`
+/// This overload forward a `term` unchanged
+template <class T>
+  requires term<std::remove_cvref_t<T>>
+[[nodiscard]]
+constexpr auto to_term(T&& value) -> T&&
+{
+  return std::forward<T>(value);
+}
+
+/// returns a `term`
+/// This overload creates a `constant`
+template <class T>
+  requires std::signed_integral<T> or std::floating_point<T>
+[[nodiscard]]
+constexpr auto to_term(const T& value) -> constant<T>
+{
+  return constant<T>{value};
+}
+
+/// a type that can be implicitly promoted to a `term`
+///
+template <class T>
+concept term_promotable =  //
+    term<T> or             //
+    requires (T a) {
+      { to_term(a) };
+    };
+
+/// obtain the term type after promotion
+/// @{
+template <class T, bool = term_promotable<T>>
+struct term_promoted_type
+{
+  using type = decltype(auto{to_term(std::declval<T>())});
+};
+template <class T>
+struct term_promoted_type<T, false>
+{};
+template <class T>
+using term_promoted_type_t = typename term_promoted_type<T>::type;
+/// @}
+
+}  // namespace sel

--- a/sel/test/plus_test.cpp
+++ b/sel/test/plus_test.cpp
@@ -34,6 +34,16 @@ auto main() -> int
     );
   };
 
+  "binary + can implicit convert a signed integer or floating point type to `constant`"_ctest =
+      [] {
+        return expect(
+            eq(sel::plus{sel::constant{3}, x}, 3 + x) and           //
+            eq(sel::plus{x, sel::constant{3.0}}, x + 3.0) and       //
+            eq(sel::plus{x, y, sel::constant{0}}, (x + y) + 0) and  //
+            eq(sel::plus{x, y, sel::constant{3}}, (x + y) + (1 + 2))
+        );
+      };
+
   "+ can be used with more than 2 arguments"_ctest = [] {
     return expect(
         eq(sel::plus{x, y, z}, x + y + z) and             //


### PR DESCRIPTION
Allow implicit conversion of integers and floating point types to
`sel::constant` when adding to a `term` or `plus` value.

Change-Id: I8f2893a4abcbcc561dd193c80a0533af7dde4a0b