### PR TITLE
define a formatter for nary operations

### DIFF
--- a/sel/BUILD.bazel
+++ b/sel/BUILD.bazel
@@ -23,6 +23,7 @@ cc_library(
     deps = [
         ":term",
         ":term_promotable",
+        "//sel/detail:nary_op_formatter",
     ],
 )
 
@@ -32,6 +33,7 @@ cc_library(
     deps = [
         ":term",
         ":term_promotable",
+        "//sel/detail:nary_op_formatter",
     ],
 )
 

--- a/sel/detail/BUILD.bazel
+++ b/sel/detail/BUILD.bazel
@@ -1,0 +1,14 @@
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
+
+package(default_visibility = ["//sel:__subpackages__"])
+
+cc_library(
+    name = "nary_op_formatter",
+    hdrs = ["nary_op_formatter.hpp"],
+    deps = [":string_literal"],
+)
+
+cc_library(
+    name = "string_literal",
+    hdrs = ["string_literal.hpp"],
+)

--- a/sel/detail/nary_op_formatter.hpp
+++ b/sel/detail/nary_op_formatter.hpp
@@ -1,0 +1,72 @@
+#pragma once
+
+#include "sel/detail/string_literal.hpp"
+
+#include <concepts>
+#include <cstddef>
+#include <format>
+#include <tuple>
+#include <utility>
+
+namespace sel::detail {
+
+/// formatter for n-ary operations
+/// @tparam delim infix symbol between operands
+/// @tparam Args operand types
+///
+template <string_literal delim, class... Args>
+struct nary_op_formatter
+{
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-const-or-ref-data-members)
+  const std::tuple<Args...>& args;
+
+  /// implicit constructor from an n-ary operation value
+  ///
+  template <class T>
+    requires requires (const T& value) {
+      { value.args } -> std::same_as<const std::tuple<Args...>&>;
+    }
+  constexpr nary_op_formatter(const T& value)
+      : args{value.args}
+  {}
+};
+
+}  // namespace sel::detail
+
+template <auto delim, class... Args, class Char>
+struct ::std::formatter<sel::detail::nary_op_formatter<delim, Args...>, Char>
+{
+  template <bool first>
+  static constexpr auto fmt = [] {
+    if constexpr (first) {
+      return "{}";
+    } else {
+      return " " + delim + " {}";
+    }
+  }();
+
+  constexpr auto parse(std::basic_format_parse_context<Char>& ctx)
+  {
+    return ctx.begin();
+  }
+
+  template <class O>
+  constexpr auto format(
+      ::sel::detail::nary_op_formatter<delim, Args...> expr,
+      std::basic_format_context<O, Char>& ctx
+  ) const
+  {
+    auto out = ctx.out();
+    out = std::format_to(out, "(");
+
+    [&]<std::size_t... Is>(std::index_sequence<Is...>) {
+      auto _ = {(
+          out = std::format_to(out, fmt < Is == 0 >, std::get<Is>(expr.args)),
+          true
+      )...};
+    }(std::index_sequence_for<Args...>{});
+
+    out = std::format_to(out, ")");
+    return out;
+  }
+};

--- a/sel/detail/string_literal.hpp
+++ b/sel/detail/string_literal.hpp
@@ -1,0 +1,62 @@
+#pragma once
+
+#include <algorithm>
+#include <array>
+#include <cstddef>
+#include <string_view>
+
+namespace sel::detail {
+
+// NOLINTBEGIN(modernize-avoid-c-arrays)
+
+/// string-like type with consteval concatenation
+///
+template <std::size_t N>
+struct string_literal
+{
+  // this member is public so that `string_literal` is structural
+  std::array<char, N> chars{};
+
+  consteval string_literal() = default;
+  consteval string_literal(const char (&str)[N + 1])
+  {
+    std::copy_n(std::begin(str), N, chars.begin());
+  }
+
+  consteval operator std::string_view() const
+  {
+    return std::string_view{chars};
+  }
+
+  template <std::size_t M>
+  friend consteval auto
+  operator+(const string_literal& lhs, const string_literal<M>& rhs)
+  {
+    auto joined = string_literal<N + M>{};
+
+    auto [_, it] = std::ranges::copy(lhs.chars, joined.chars.begin());
+    auto _ = std::ranges::copy(rhs.chars, it);
+
+    return joined;
+  }
+
+  template <std::size_t M>
+  friend consteval auto
+  operator+(const char (&lhs)[M], const string_literal& rhs)
+  {
+    return string_literal<M - 1>{lhs} + rhs;
+  }
+  template <std::size_t M>
+  friend consteval auto
+  operator+(const string_literal& lhs, const char (&rhs)[M])
+  {
+    return lhs + string_literal<M - 1>{rhs};
+  }
+};
+
+template <std::size_t N>
+string_literal(const char (&)[N]) -> string_literal<N - 1>;
+
+// NOLINTEND(modernize-avoid-c-arrays)
+
+}  // namespace sel::detail

--- a/sel/multiplies.hpp
+++ b/sel/multiplies.hpp
@@ -1,13 +1,12 @@
 #pragma once
 
+#include "sel/detail/nary_op_formatter.hpp"
 #include "sel/term.hpp"
 #include "sel/term_promotable.hpp"
 
 #include <cstddef>
 #include <format>
-#include <string_view>
 #include <tuple>
-#include <utility>
 
 namespace sel {
 
@@ -63,26 +62,5 @@ constexpr auto operator*(const T1& x, const T2& y)
 
 template <class... Args, class Char>
 struct ::std::formatter<::sel::multiplies<Args...>, Char>
-    : std::formatter<std::string_view, Char>
-{
-  template <class O>
-  constexpr auto format(
-      const ::sel::multiplies<Args...>& expr,
-      std::basic_format_context<O, Char>& ctx
-  ) const
-  {
-    auto out = ctx.out();
-    out = std::format_to(out, "(");
-
-    [&]<std::size_t... Is>(std::index_sequence<Is...>) {
-      auto fmt = [](bool first) { return first ? "{}" : " * {}"; };
-
-      auto _ = {(
-          out = std::format_to(out, fmt(Is == 0), std::get<Is>(expr.args)), 0
-      )...};
-    }(std::index_sequence_for<Args...>{});
-
-    out = std::format_to(out, ")");
-    return out;
-  }
-};
+    : std::formatter<::sel::detail::nary_op_formatter<"*", Args...>, Char>
+{};

--- a/sel/plus.hpp
+++ b/sel/plus.hpp
@@ -1,13 +1,12 @@
 #pragma once
 
+#include "sel/detail/nary_op_formatter.hpp"
 #include "sel/term.hpp"
 #include "sel/term_promotable.hpp"
 
 #include <cstddef>
 #include <format>
-#include <string_view>
 #include <tuple>
-#include <utility>
 
 namespace sel {
 
@@ -62,25 +61,5 @@ constexpr auto operator+(const T1& x, const T2& y)
 
 template <class... Args, class Char>
 struct ::std::formatter<::sel::plus<Args...>, Char>
-    : std::formatter<std::string_view, Char>
-{
-  template <class O>
-  constexpr auto format(
-      const ::sel::plus<Args...>& expr, std::basic_format_context<O, Char>& ctx
-  ) const
-  {
-    auto out = ctx.out();
-    out = std::format_to(out, "(");
-
-    [&]<std::size_t... Is>(std::index_sequence<Is...>) {
-      auto fmt = [](bool first) { return first ? "{}" : " + {}"; };
-
-      auto _ = {(
-          out = std::format_to(out, fmt(Is == 0), std::get<Is>(expr.args)), 0
-      )...};
-    }(std::index_sequence_for<Args...>{});
-
-    out = std::format_to(out, ")");
-    return out;
-  }
-};
+    : std::formatter<::sel::detail::nary_op_formatter<"+", Args...>, Char>
+{};


### PR DESCRIPTION
Provide a common formatter for nary operations, which displays an infix
symbol between the operands. `multiplies` and `plus` are updated to use
this formatter.

To allow compile-time evaluation of the format string containing the
infix symbol, this PR also defines a `string_literal` type that performs
compile-time string concatenation.

Change-Id: Ibbe616f8b42bb261669005d4511e22f36fa07815