### PR TITLE
autorebase pull requests targeting `main`

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -6,7 +6,6 @@ on:
   pull_request:
     branches: ["*"]
     types: [synchronize, opened, reopened, edited]
-  merge_group:
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/rebase-pull-request.yml
+++ b/.github/workflows/rebase-pull-request.yml
@@ -1,0 +1,28 @@
+name: rebase-pull-request
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      pull-request:
+        default: "stale"
+        description: |
+          pull request to rebase
+      base-branch:
+        default: "main"
+        description: |
+          pull request to rebase
+
+jobs:
+  rebase-pull-request:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # update branches used by pull requests
+      pull-requests: write # update pull request base branch
+    steps:
+      - uses: oliverlee/rebase-pull-request@v0
+        with:
+          checkout-ssh-key: ${{ secrets.PR_UPDATE_DEPLOY_KEY }}
+          pull-request: ${{ github.event.inputs.pull-request || 'stale' }}
+          base-branch: ${{ github.event.inputs.base-branch || 'main' }}


### PR DESCRIPTION
Add a workflow to update pull requests targeting main whenever main is
updated. This allows multiple pull requests targeting main set to
automerge to be merged, as long as each pull request has a successful
rebase.

This replaces use of merge queues, which do not handle stacked PRs. The
second PR in a stack has a merge conflict as soon as the first is
merged and is then removed from the merge queue.

This allows automerge of a stack of PRs by use of branch naming
convention and the automerge option. Branches with pattern `I*` have a
ruleset requiring 10 review approvals to merge - effectively preventing
stacked PRs from merging into each other. However, existing review
approvals and the automerge option persist after a PR has been rebased
and the base branch updated to main.

This workflow uses a deploy key to allow the GitHub actions bot to
update protected branches. During the update action, the GitHub actions
bot pushes unverified commits to a temporary branch in order to later
create a signed commit. A separate ruleset requires a deploy key to push
to these temporary branches.

For more information, see this discussion[^1] on allowing the
GitHub actions bot to push to protected branches and this discussion[^2]
on signing commits with the GitHub actions bot.

[^1]: https://github.com/orgs/community/discussions/25305#discussioncomment-10728028
[^2]: https://github.com/orgs/community/discussions/50055#discussioncomment-13460641

Change-Id: I6dc9557fc871ea26c6c1825fbe26c00c8e7db2cf