### PR TITLE
update `plus` and `multiplies` to model `operation`

### DIFF
--- a/sel/BUILD.bazel
+++ b/sel/BUILD.bazel
@@ -21,18 +21,28 @@ cc_library(
     name = "multiplies",
     hdrs = ["multiplies.hpp"],
     deps = [
+        ":operation",
         ":term",
         ":term_promotable",
+        "//sel/detail:is_specialization_of",
         "//sel/detail:nary_op_formatter",
     ],
+)
+
+cc_library(
+    name = "operation",
+    hdrs = ["operation.hpp"],
+    deps = [":strongly_ordered"],
 )
 
 cc_library(
     name = "plus",
     hdrs = ["plus.hpp"],
     deps = [
+        ":operation",
         ":term",
         ":term_promotable",
+        "//sel/detail:is_specialization_of",
         "//sel/detail:nary_op_formatter",
     ],
 )
@@ -45,7 +55,10 @@ cc_library(
 cc_library(
     name = "term",
     hdrs = ["term.hpp"],
-    deps = [":strongly_ordered"],
+    deps = [
+        ":operation",
+        ":strongly_ordered",
+    ],
 )
 
 cc_library(

--- a/sel/constant.hpp
+++ b/sel/constant.hpp
@@ -14,7 +14,7 @@ namespace sel {
 /// symbol that represents a specified quantity in an expression
 template <class T>
   requires std::signed_integral<T> or std::floating_point<T>
-class constant
+class constant : public term_base
 {
   T value_{};
 
@@ -78,9 +78,6 @@ public:
     return common_constant(x.value()) <=> common_constant(y.value());
   }
 };
-
-template <class T>
-constexpr bool enable_as_term<constant<T>> = true;
 
 }  // namespace sel
 

--- a/sel/detail/BUILD.bazel
+++ b/sel/detail/BUILD.bazel
@@ -3,6 +3,11 @@ load("@rules_cc//cc:cc_library.bzl", "cc_library")
 package(default_visibility = ["//sel:__subpackages__"])
 
 cc_library(
+    name = "is_specialization_of",
+    hdrs = ["is_specialization_of.hpp"],
+)
+
+cc_library(
     name = "nary_op_formatter",
     hdrs = ["nary_op_formatter.hpp"],
     deps = [":string_literal"],

--- a/sel/detail/is_specialization_of.hpp
+++ b/sel/detail/is_specialization_of.hpp
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <type_traits>
+
+namespace sel::detail {
+
+// https://wg21.link/p2098
+
+template <class T, template <class...> class primary>
+struct is_specialization_of : std::false_type
+{};
+
+template <template <class...> class primary, class... Args>
+struct is_specialization_of<primary<Args...>, primary> : std::true_type
+{};
+
+template <class T, template <class...> class primary>
+inline constexpr bool is_specialization_of_v =
+    is_specialization_of<T, primary>::value;
+
+}  // namespace sel::detail

--- a/sel/multiplies.hpp
+++ b/sel/multiplies.hpp
@@ -1,6 +1,8 @@
 #pragma once
 
+#include "sel/detail/is_specialization_of.hpp"
 #include "sel/detail/nary_op_formatter.hpp"
+#include "sel/operation.hpp"
 #include "sel/term.hpp"
 #include "sel/term_promotable.hpp"
 
@@ -14,15 +16,11 @@ namespace sel {
 ///
 template <term... Args>
   requires (sizeof...(Args) != 0)
-struct multiplies
+struct multiplies : operation_interface<multiplies<Args...>>
 {
-  std::tuple<Args...> args{};
-
   constexpr multiplies(const Args&... args)
-      : args{args...}
+      : operation_interface<multiplies>{args...}
   {}
-
-  friend auto operator<=>(const multiplies&, const multiplies&) = default;
 
   template <term... Ts>
   [[nodiscard]]
@@ -37,6 +35,7 @@ struct multiplies
   }
 
   template <term_promotable T>
+    requires (not detail::is_specialization_of_v<T, multiplies>)
   [[nodiscard]]
   friend constexpr auto operator*(const multiplies& x, const T& y)
   {
@@ -44,6 +43,7 @@ struct multiplies
   }
 
   template <term_promotable T>
+    requires (not detail::is_specialization_of_v<T, multiplies>)
   [[nodiscard]]
   friend constexpr auto operator*(const T& x, const multiplies& y)
   {

--- a/sel/operation.hpp
+++ b/sel/operation.hpp
@@ -1,0 +1,44 @@
+#pragma once
+
+#include "sel/strongly_ordered.hpp"
+
+#include <concepts>
+#include <tuple>
+
+namespace sel {
+
+template <class>
+struct operation_interface;
+
+/// deriving from `operation_interface` enables types to model `operation`
+template <template <class...> class derived, class... Args>
+  requires (std::copyable<Args> and ...) and  //
+           (strongly_ordered<Args> and ...)
+struct operation_interface<derived<Args...>>
+{
+  std::tuple<Args...> args;
+
+  constexpr operation_interface(const Args&... args)
+      : args{args...}
+  {}
+
+  friend auto
+  operator<=>(const operation_interface&, const operation_interface&) = default;
+};
+
+/// function that takes one or more arguments
+///
+/// A type that models `operation` must be `copyable` and must explicitly
+/// declare itself as usable as a `term` by inheriting from
+/// `operation_interface`.
+///
+/// Additionally, all valid values of the type must be totally ordered in order
+/// to allow reordering of terms in an expression.
+template <class T>
+concept operation =                          //
+    (not std::default_initializable<T>) and  //
+    std::copyable<T> and                     //
+    strongly_ordered<T> and                  //
+    std::derived_from<T, operation_interface<T>>;
+
+}  // namespace sel

--- a/sel/plus.hpp
+++ b/sel/plus.hpp
@@ -1,6 +1,8 @@
 #pragma once
 
+#include "sel/detail/is_specialization_of.hpp"
 #include "sel/detail/nary_op_formatter.hpp"
+#include "sel/operation.hpp"
 #include "sel/term.hpp"
 #include "sel/term_promotable.hpp"
 
@@ -14,15 +16,11 @@ namespace sel {
 ///
 template <term... Args>
   requires (sizeof...(Args) != 0)
-struct plus
+struct plus : operation_interface<plus<Args...>>
 {
-  std::tuple<Args...> args{};
-
   constexpr plus(const Args&... args)
-      : args{args...}
+      : operation_interface<plus>{args...}
   {}
-
-  friend auto operator<=>(const plus&, const plus&) = default;
 
   template <term... Ts>
   [[nodiscard]]
@@ -36,6 +34,7 @@ struct plus
   }
 
   template <term_promotable T>
+    requires (not detail::is_specialization_of_v<T, plus>)
   [[nodiscard]]
   friend constexpr auto operator+(const plus& x, const T& y)
   {
@@ -43,6 +42,7 @@ struct plus
   }
 
   template <term_promotable T>
+    requires (not detail::is_specialization_of_v<T, plus>)
   [[nodiscard]]
   friend constexpr auto operator+(const T& x, const plus& y)
   {

--- a/sel/term.hpp
+++ b/sel/term.hpp
@@ -1,19 +1,28 @@
 #pragma once
 
+#include "sel/operation.hpp"
 #include "sel/strongly_ordered.hpp"
 
 #include <concepts>
 
 namespace sel {
 
+/// deriving from `term_base` enables types to model `term`
+struct term_base
+{
+  friend auto operator<=>(const term_base&, const term_base&) = default;
+};
+
 /// hook for types to declare usability as a term
 template <class T>
-constexpr bool enable_as_term = false;
+constexpr bool enable_as_term =  //
+    std::derived_from<T, term_base> or operation<T>;
 
 /// a symbol that represents a quantity in an expression
 ///
 /// A type that models `term` must be `copyable` and must explicitly declare
-/// itself as usable as a `term` by specializing `enable_as_term`.
+/// itself as usable as a `term` by specializing `enable_as_term` or inheriting
+/// from `term_base`.
 ///
 /// Additionally, all valid values of the type must be totally ordered in order
 /// to allow reordering of terms in an expression.

--- a/sel/term_promotable.hpp
+++ b/sel/term_promotable.hpp
@@ -9,7 +9,7 @@
 namespace sel {
 
 /// returns a `term`
-/// This overload forward a `term` unchanged
+/// This overload forwards a `term` unchanged
 template <class T>
   requires term<std::remove_cvref_t<T>>
 [[nodiscard]]

--- a/sel/test/nary_op_test.cpp
+++ b/sel/test/nary_op_test.cpp
@@ -109,4 +109,28 @@ auto main() -> int
 
     return expect(true);
   };
+
+  "nary op of nary op ..."_ctest = [] {
+    return expect(eq(
+        sel::plus{sel::multiplies{sel::plus{a, b}, x}, y},  //
+        (((a + b) * x) + y)
+    ));
+  };
+
+  "can define nested nary ops with only 1 argument"_ctest = [] {
+    auto _ = sel::plus{sel::multiplies{sel::constant{1}}};
+    return expect(true);
+  };
+
+  "can define the same nested nary op with only 1 argument"_ctest = [] {
+    auto _ = sel::plus{sel::plus{sel::constant{1}}};
+    return expect(true);
+  };
+
+  "expression has normal operator precedence"_ctest = [] {
+    return expect(eq(
+        sel::plus{sel::multiplies{a, x}, sel::multiplies{b, y}},  //
+        a * x + b * y
+    ));
+  };
 }

--- a/sel/variable.hpp
+++ b/sel/variable.hpp
@@ -12,7 +12,7 @@
 namespace sel {
 
 /// symbol that represents an unspecified quantity in an expression
-class variable
+class variable : public term_base
 {
   std::string value_{};
 
@@ -34,10 +34,6 @@ public:
   friend auto operator<=>(const variable&, const variable&)
       -> std::strong_ordering = default;
 };
-
-template <>
-// NOLINTNEXTLINE(misc-definitions-in-headers)
-constexpr bool enable_as_term<variable> = true;
 
 }  // namespace sel
 


### PR DESCRIPTION
Define concept `operation` - a function of 1 or more arguments. All
`operation`s are also defined to model `term`.

`plus` and `multiplies` model `operation` by inheriting from
`operation_interface`, allowing `plus` to be an argument of `multiplies`
and vice-versa.

`enable_as_term` now uses a default value of `derived_from<term_base>`,
where `term_base` is an empty type that can be used to allow a type to
model `term`.

Change-Id: I0a8176aa936bbb7f9088f1c2a46a8abdb090384f