### PR TITLE
speed up determination of lint targets in `check` workflow

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -39,4 +39,7 @@ coverage --experimental_generate_llvm_lcov
 # https://github.com/bazelbuild/bazel/issues/23719
 coverage:macos --test_env=GCOV_PREFIX_STRIP=10
 
+build:local-config-cc --action_env="BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=0"
+build:local-config-cc --extra_toolchains=@@rules_cc++cc_configure_extension+local_config_cc_toolchains//:all
+
 try-import %workspace%/user.bazelrc

--- a/.github/actions/ci-env-setup/action.yml
+++ b/.github/actions/ci-env-setup/action.yml
@@ -7,6 +7,12 @@ description: |
 inputs:
   buildbuddy-api-key:
     required: true
+    description: |
+      BuildBuddy API key to access the remote cache.
+  external-cache-key:
+    default: ${{ runner.os }}-default
+    description: |
+      Key specifying which cache to restore.
 
 runs:
   using: "composite"
@@ -27,4 +33,4 @@ runs:
       with:
         path: |
           ~/bazel_external_deps
-        key: bazel-external-cache-${{ runner.os }}
+        key: bazel-external-cache-${{ inputs.external-cache-key }}

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -52,10 +52,12 @@ jobs:
     - uses: ./.github/actions/ci-env-setup
       with:
         buildbuddy-api-key: ${{ secrets.BUILDBUDDY_API_KEY }}
+        external-cache-key: ${{ runner.os }}-local-config-cc
     - id: query
       run: |
         targets=$(\
           bazel cquery \
+            --config=local-config-cc \
             --output starlark \
             --starlark:expr='repr(target).split(" ")[-1].removesuffix(">") if "CcInfo" in providers(target).keys() and not repr(target).startswith("<alias") else ""' \
             -- \

--- a/.github/workflows/external-cache.yml
+++ b/.github/workflows/external-cache.yml
@@ -27,9 +27,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os:
-          - 'ubuntu-latest'
-          - 'macos-latest'
+        include:
+          - config: 'default'
+            os: 'ubuntu-latest'
+          - config: 'default'
+            os: 'macos-latest'
+          - config: 'local-config-cc'
+            os: 'ubuntu-latest'
     runs-on: ${{ matrix.os }}
     permissions:
       actions: write
@@ -40,10 +44,18 @@ jobs:
       with:
         buildbuddy-api-key: ${{ secrets.BUILDBUDDY_API_KEY }}
     - name: fetch external deps
+      if: matrix.config == 'default'
       run: |
         bazel vendor \
           --vendor_dir=~/bazel_external_deps \
           //sel/...
+    - name: fetch external deps
+      if: matrix.config == 'local-config-cc'
+      run: |
+        bazel vendor \
+          --vendor_dir=~/bazel_external_deps \
+          --config=local-config-cc \
+          //...
     - name: print vendored external deps
       run: |
         ls -al ~/bazel_external_deps/
@@ -53,4 +65,4 @@ jobs:
       with:
         path: |
           ~/bazel_external_deps
-        key: bazel-external-cache-${{ runner.os }}
+        key: bazel-external-cache-${{ runner.os }}-${{ matrix.config }}


### PR DESCRIPTION
Establish a new set of external dependency caches with the following
keys:
- Linux-default
- macOS-default
- Linux-local-config-cc

`Linux-local-config-cc` is created using `--config=local-config-cc` on
an Ubuntu runner where `local-config-cc` uses the local C++ toolchain
configuration.

Use of `--config=local-config-cc` allows the `clang-tidy-targets` job to
avoid the need to download the hermetic LLVM toolchain - any C++
toolchain is sufficient to perform `bazel cquery` in order to obtain a
list of targets.

Change-Id: I4dd3e1cdf3eed29442c62803710e70442dcabe14