### PR TITLE
update `constant` and `variable` to model `leaf`

### DIFF
--- a/sel/BUILD.bazel
+++ b/sel/BUILD.bazel
@@ -30,6 +30,12 @@ cc_library(
 )
 
 cc_library(
+    name = "leaf",
+    hdrs = ["leaf.hpp"],
+    deps = [":strongly_ordered"],
+)
+
+cc_library(
     name = "operation",
     hdrs = ["operation.hpp"],
     deps = [":strongly_ordered"],
@@ -56,8 +62,8 @@ cc_library(
     name = "term",
     hdrs = ["term.hpp"],
     deps = [
+        ":leaf",
         ":operation",
-        ":strongly_ordered",
     ],
 )
 

--- a/sel/constant.hpp
+++ b/sel/constant.hpp
@@ -1,12 +1,11 @@
 #pragma once
 
 #include "sel/contract.hpp"
+#include "sel/leaf.hpp"
 #include "sel/strongly_ordered.hpp"
-#include "sel/term.hpp"
 
 #include <compare>
 #include <concepts>
-#include <format>
 #include <type_traits>
 
 namespace sel {
@@ -14,7 +13,7 @@ namespace sel {
 /// symbol that represents a specified quantity in an expression
 template <class T>
   requires std::signed_integral<T> or std::floating_point<T>
-class constant : public term_base
+class constant : public leaf_base<constant<T>>
 {
   T value_{};
 
@@ -80,15 +79,3 @@ public:
 };
 
 }  // namespace sel
-
-template <class T, class Char>
-struct ::std::formatter<::sel::constant<T>, Char> : std::formatter<T, Char>
-{
-  template <class O>
-  constexpr auto format(
-      const ::sel::constant<T>& x, std::basic_format_context<O, Char>& ctx
-  ) const
-  {
-    return std::format_to(ctx.out(), "{}", x.value());
-  }
-};

--- a/sel/leaf.hpp
+++ b/sel/leaf.hpp
@@ -1,0 +1,51 @@
+#pragma once
+
+#include "sel/strongly_ordered.hpp"
+
+#include <concepts>
+#include <format>
+
+namespace sel {
+
+// deriving from `leaf_base` allows the type model `leaf`
+template <class Derived>
+class leaf_base
+{
+  friend Derived;
+  leaf_base() = default;
+
+  friend auto operator<=>(const leaf_base&, const leaf_base&) = default;
+};
+
+/// terminal element in an expression tree
+///
+/// A type that models `leaf` must be `copyable` and must explicitly declare
+/// itself as usable as a `term` by inheriting from `leaf_base`.
+///
+/// Additionally, all valid values of the type must be totally ordered in order
+/// to allow reordering of terms in an expression.
+template <class T>
+concept leaf =                         //
+    requires (T x) { x.value(); } and  //
+    std::copyable<T> and               //
+    strongly_ordered<T> and            //
+    std::derived_from<T, leaf_base<T>>;
+
+}  // namespace sel
+
+template <class L, class Char>
+  requires std::derived_from<L, ::sel::leaf_base<L>>
+struct ::std::formatter<L, Char>
+{
+  constexpr auto parse(std::basic_format_parse_context<Char>& ctx)
+  {
+    return ctx.begin();
+  }
+
+  template <class O>
+  constexpr auto
+  format(const L& x, std::basic_format_context<O, Char>& ctx) const
+  {
+    return std::format_to(ctx.out(), "{}", x.value());
+  }
+};

--- a/sel/term.hpp
+++ b/sel/term.hpp
@@ -1,35 +1,14 @@
 #pragma once
 
+#include "sel/leaf.hpp"
 #include "sel/operation.hpp"
-#include "sel/strongly_ordered.hpp"
-
-#include <concepts>
 
 namespace sel {
 
-/// deriving from `term_base` enables types to model `term`
-struct term_base
-{
-  friend auto operator<=>(const term_base&, const term_base&) = default;
-};
-
-/// hook for types to declare usability as a term
-template <class T>
-constexpr bool enable_as_term =  //
-    std::derived_from<T, term_base> or operation<T>;
-
 /// a symbol that represents a quantity in an expression
 ///
-/// A type that models `term` must be `copyable` and must explicitly declare
-/// itself as usable as a `term` by specializing `enable_as_term` or inheriting
-/// from `term_base`.
-///
-/// Additionally, all valid values of the type must be totally ordered in order
-/// to allow reordering of terms in an expression.
+/// A type that models `term` must model `operation` or `leaf`.
 template <class T>
-concept term =               //
-    std::copyable<T> and     //
-    strongly_ordered<T> and  //
-    enable_as_term<T>;
+concept term = operation<T> or leaf<T>;
 
 }  // namespace sel

--- a/sel/variable.hpp
+++ b/sel/variable.hpp
@@ -1,18 +1,15 @@
 #pragma once
 
 #include "sel/contract.hpp"
-#include "sel/term.hpp"
+#include "sel/leaf.hpp"
 
-#include <compare>
-#include <format>
 #include <string>
-#include <string_view>
 #include <utility>
 
 namespace sel {
 
 /// symbol that represents an unspecified quantity in an expression
-class variable : public term_base
+class variable : public leaf_base<variable>
 {
   std::string value_{};
 
@@ -31,21 +28,7 @@ public:
     return std::forward<Self>(self).value_;
   }
 
-  friend auto operator<=>(const variable&, const variable&)
-      -> std::strong_ordering = default;
+  friend auto operator<=>(const variable&, const variable&) = default;
 };
 
 }  // namespace sel
-
-template <class Char>
-struct ::std::formatter<::sel::variable, Char>
-    : std::formatter<std::string_view, Char>
-{
-  template <class O>
-  constexpr auto format(
-      const ::sel::variable& x, std::basic_format_context<O, Char>& ctx
-  ) const
-  {
-    return std::format_to(ctx.out(), "{}", x.value());
-  }
-};


### PR DESCRIPTION
Define a `leaf` concept - these are the terminal elements in an expression tree
that do not model `operation`.

Change-Id: I54f8f6c67373abd158ac84fb0b2ec92017a2bb29