### PR TITLE
construct `tree` from elements

### DIFF
--- a/sel/BUILD.bazel
+++ b/sel/BUILD.bazel
@@ -81,10 +81,12 @@ cc_library(
     hdrs = ["tree.hpp"],
     deps = [
         ":constant",
+        ":contract",
         ":leaf",
         ":multiplies",
         ":operation",
         ":plus",
+        ":term",
         ":variable",
         "//sel/detail:tuple_ref",
         "//sel/detail:tuple_transform_reduce",

--- a/sel/multiplies.hpp
+++ b/sel/multiplies.hpp
@@ -59,4 +59,9 @@ constexpr auto operator*(const T1& x, const T2& y)
   return multiplies{to_term(x), to_term(y)};
 }
 
+namespace op {
+/// tag type denoting the `multiplies` operation
+using multiplies = operation_tag<multiplies>;
+}  // namespace op
+
 }  // namespace sel

--- a/sel/operation.hpp
+++ b/sel/operation.hpp
@@ -3,6 +3,7 @@
 #include "sel/strongly_ordered.hpp"
 
 #include <concepts>
+#include <cstddef>
 #include <format>
 #include <tuple>
 
@@ -11,12 +12,18 @@ namespace sel {
 template <class>
 struct operation_interface;
 
+template <template <class...> class op>
+struct operation_tag
+{};
+
 /// deriving from `operation_interface` enables types to model `operation`
 template <template <class...> class op, class... Args>
   requires (std::copyable<Args> and ...) and  //
            (strongly_ordered<Args> and ...)
 struct operation_interface<op<Args...>>
 {
+  using op_tag = operation_tag<op>;
+
   std::tuple<Args...> args;
 
   constexpr operation_interface(const Args&... args)

--- a/sel/plus.hpp
+++ b/sel/plus.hpp
@@ -58,4 +58,9 @@ constexpr auto operator+(const T1& x, const T2& y)
   return plus{to_term(x), to_term(y)};
 }
 
+namespace op {
+/// tag type denoting the `plus` operation
+using plus = operation_tag<plus>;
+}  // namespace op
+
 }  // namespace sel

--- a/sel/test/tree_test.cpp
+++ b/sel/test/tree_test.cpp
@@ -1,7 +1,13 @@
 #include "sel/constant.hpp"
+#include "sel/multiplies.hpp"
+#include "sel/plus.hpp"
 #include "sel/tree.hpp"
 #include "sel/variable.hpp"
 #include "skytest/skytest.hpp"
+
+#include <ranges>
+#include <type_traits>
+#include <utility>
 
 auto main() -> int
 {
@@ -33,9 +39,42 @@ auto main() -> int
     );
   };
 
+  "tree constructible from elements"_ctest = [] {
+    return expect(
+        eq(x, sel::tree{std::in_place_type<sel::variable>, "x"}) and          //
+        eq(a, sel::tree{std::in_place_type<sel::constant<int>>, 1}) and       //
+        eq(b, sel::tree{std::in_place_type<sel::constant<double>>, 2.0}) and  //
+        eq(x + a, sel::tree{std::in_place_type<sel::op::plus>, x, a}) and     //
+        eq(a * x + b,
+           sel::tree{std::in_place_type<sel::op::plus>, a * x, b}) and  //
+        eq(a + a + a,
+           sel::tree{
+               std::in_place_type<sel::op::plus>,
+               std::from_range,
+               std::views::repeat(a, 3)
+           })
+    );
+  };
+
+  "tree op construction requires valid number of args"_ctest = [] {
+    return expect(
+        not pred(
+            std::is_constructible<
+                sel::tree,
+                std::in_place_type_t<sel::op::plus>>{}
+        ) and
+        not pred(
+            std::is_constructible<
+                sel::tree,
+                std::in_place_type_t<sel::op::multiplies>>{}
+        )
+    );
+  };
+
   "trees are comparable"_ctest = [] {
     return expect(
         eq(sel::tree{x + a}, sel::tree{x + a}) and      //
+        ne(sel::tree{x + a + b}, sel::tree{x + a}) and  //
         ne(sel::tree{x + b}, sel::tree{x + a}) and      //
         ne(sel::tree{x * a}, sel::tree{x + a}) and      //
         eq(sel::tree{a * x + b}, sel::tree{a * x + b})  //

--- a/sel/tree.hpp
+++ b/sel/tree.hpp
@@ -1,17 +1,23 @@
 #pragma once
 
 #include "sel/constant.hpp"
+#include "sel/contract.hpp"
 #include "sel/detail/tuple_ref.hpp"
 #include "sel/detail/tuple_transform_reduce.hpp"
 #include "sel/leaf.hpp"
 #include "sel/multiplies.hpp"
 #include "sel/operation.hpp"
 #include "sel/plus.hpp"
+#include "sel/term.hpp"
 #include "sel/variable.hpp"
 
+#include <concepts>
 #include <cstddef>
 #include <functional>
+#include <ranges>
 #include <tuple>
+#include <type_traits>
+#include <utility>
 #include <variant>
 #include <vector>
 
@@ -21,43 +27,83 @@ namespace sel {
 class tree
 {
   /// internal (non-terminal) element describing an operation
-  template <template <class...> class op>
-  struct node
+  template <class OpTag>
+  struct op_node
   {
-    template <class... Args>
-    using operation_type = op<Args...>;
-
     std::vector<tree> args;
 
     template <class... Args>
-    constexpr explicit node(const Args&... args)
-        : args{tree{args}...}
+      requires (
+          (std::same_as<tree, std::remove_cvref_t<Args>> or
+           term<std::remove_cvref_t<Args>>) and
+          ...
+      )
+    constexpr explicit op_node(Args&&... args)
+        : args{tree{std::forward<Args>(args)}...}
     {}
 
-    friend auto operator==(const node&, const node&) -> bool = default;
+    constexpr op_node(std::from_range_t, std::ranges::sized_range auto& values)
+    {
+      SEL_PRECONDITION(std::ranges::size(values) != 0);
+      args.reserve(std::ranges::size(values));
+
+      for (auto&& value : values) {
+        args.emplace_back(std::forward<decltype(value)>(value));
+      }
+    }
+
+    friend auto operator==(const op_node&, const op_node&) -> bool = default;
   };
 
   using node_type = std::variant<
       constant<int>,
       constant<double>,
       variable,
-      node<plus>,
-      node<multiplies>>;
+      op_node<op::plus>,
+      op_node<op::multiplies>>;
 
   node_type value_;
 
 public:
-  /// construct a `tree` from a `leaf`
-  constexpr explicit tree(const leaf auto& value)
-      : value_{value}
+  /// construct from a `leaf`
+  template <class T>
+    requires leaf<std::remove_cvref_t<T>>
+  constexpr explicit tree(T&& value)
+      : value_{std::forward<T>(value)}
   {}
 
-  /// construct a `tree` from an `operation`
-  template <template <class...> class op, class... Args>
-    requires operation<op<Args...>>
-  constexpr explicit tree(const op<Args...>& expr)
-      : value_{std::make_from_tuple<node<op>>(expr.args)}
+  /// construct from an `operation`
+  template <class Op>
+    requires (not std::same_as<tree, std::remove_cvref_t<Op>>) and
+             operation<std::remove_cvref_t<Op>>
+  constexpr explicit tree(Op&& expr)
+      : value_{std::make_from_tuple<op_node<typename std::remove_cvref_t<
+            Op>::op_tag>>(std::forward<Op>(expr).args)}
   {}
+
+  /// construct from elements
+  /// @{
+  template <leaf L, class T>
+    requires std::constructible_from<L, T>
+  constexpr tree(std::in_place_type_t<L>, T&& value)
+      : value_{std::in_place_type<L>, std::forward<T>(value)}
+  {}
+
+  template <class OpTag, class... Args>
+    requires (sizeof...(Args) != 0)
+  constexpr tree(std::in_place_type_t<OpTag>, Args&&... args)
+      : value_{std::in_place_type<op_node<OpTag>>, std::forward<Args>(args)...}
+  {}
+
+  template <class OpTag>
+  constexpr tree(
+      std::in_place_type_t<OpTag>,
+      std::from_range_t,
+      std::ranges::sized_range auto&& args
+  )
+      : value_{std::in_place_type<op_node<OpTag>>, std::from_range, args}
+  {}
+  /// @}
 
   /// compare a `tree` with a `leaf`
   [[nodiscard]]
@@ -78,7 +124,7 @@ public:
   [[nodiscard]]
   constexpr auto operator==(const op<Args...>& other) const -> bool
   {
-    if (const auto value = std::get_if<node<op>>(&value_)) {
+    if (const auto value = std::get_if<op_node<operation_tag<op>>>(&value_)) {
       if (value->args.size() == sizeof...(Args)) {
         return detail::tuple_transform_reduce(
             detail::tuple_ref<sizeof...(Args)>(value->args),


### PR DESCRIPTION
Add additional constructors to `tree` to construct it from elements
instead of a `leaf` or `operation`. This allows construction of a `tree`
from sub-`tree`s.

Additionally, define tag types to denote `plus` and `multiplies`. These
tags denote the operation, but do not store operands.

Change-Id: Ideb8ce4bfe9d2c52a71355d74ba5cea57cbad579